### PR TITLE
remove kernel headers from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
 CROSS_COMPILE	?= 
-ARCH		?= x86
-KERNEL_DIR	?= /usr/src/linux
 
 CC		:= $(CROSS_COMPILE)gcc
-KERNEL_INCLUDE	:= -I$(KERNEL_DIR)/include -I$(KERNEL_DIR)/arch/$(ARCH)/include
-CFLAGS		:= -W -Wall -g $(KERNEL_INCLUDE)
+CFLAGS		:= -W -Wall -g
 LDFLAGS		:= -g
 
 all: uvc-gadget


### PR DESCRIPTION
it seems that including the header files from kernel sources
will actually confuse the compiler. most people probably
don't have kernel sources at /usr/src/linux so nothing gets
included and everything works.